### PR TITLE
Add filter parameters to specific end-points

### DIFF
--- a/fpr2par/helpers.py
+++ b/fpr2par/helpers.py
@@ -3,6 +3,9 @@ from datetime import datetime
 
 
 def _parse_offset_limit(request):
+    """Parse offset and limit values from a given Flask request and return
+    a tuple containing both.
+    """
     offset = request.args.get("offset", default=0, type=int)
     limit = request.args.get("limit", default=None, type=int)
     if limit is not None:
@@ -11,10 +14,12 @@ def _parse_offset_limit(request):
 
 
 def _split_ms(date_string):
+    """Remove microseconds from the given date string."""
     return str(date_string).split(".")[0]
 
 
 def _get_date(date_string, default):
+    """Return a date object from a given string."""
     try:
         return datetime.strptime(_split_ms(date_string), DATE_FORMAT_FULL)
     except ValueError:
@@ -25,11 +30,22 @@ def _get_date(date_string, default):
         return default
 
 
+# Date formats that can be sent via PAR requests.
 DATE_FORMAT_FULL = "%Y-%m-%d %H:%M:%S"
 DATE_FORMAT_PARTIAL = "%Y-%m-%d"
 
+# Filter headers that can be sent via PAR requests.
+GUID_HEADER = "guid"
+FILE_FORMAT_HEADER = "file-format"
+PRESERVATION_ACT_HEADER = "preservation-action-type"
+TOOL_HEADER = "tool"
+
 
 def _parse_filter_dates(request):
+    """Parses dates requested by the API caller and returns a before and after
+    date depending on what information we have available, e.g. a blank after
+    date will always return 1970-01-01.
+    """
     default_after = datetime.strptime("1970-01-01 00:00:00", DATE_FORMAT_FULL)
     default_before = datetime.strptime(
         _split_ms(datetime.now(tz=None)), DATE_FORMAT_FULL
@@ -42,3 +58,31 @@ def _parse_filter_dates(request):
     after_date = _get_date(after_date, default_after)
 
     return before_date, after_date
+
+
+def _get_filter_list(filter_header):
+    """Returns a cleaned list from the provided header string."""
+    if filter_header is None:
+        return []
+    filters = [item.strip() for item in filter_header.rstrip(",").split(",")]
+    return filters
+
+
+def _parse_filter_headers(request):
+    """Accesses request headers individually and cleans them up to be used
+    by the caller.
+
+    TODO: Validate these values so that they're conform to specific regex.
+    """
+    guid_header = _get_filter_list(request.headers.get(GUID_HEADER))
+    file_format_header = _get_filter_list(request.headers.get(FILE_FORMAT_HEADER))
+    preservation_act_header = _get_filter_list(
+        request.headers.get(PRESERVATION_ACT_HEADER)
+    )
+    tool_header = _get_filter_list(request.headers.get(TOOL_HEADER))
+    return {
+        GUID_HEADER: guid_header,
+        FILE_FORMAT_HEADER: file_format_header,
+        PRESERVATION_ACT_HEADER: preservation_act_header,
+        TOOL_HEADER: tool_header,
+    }

--- a/fpr2par/views.py
+++ b/fpr2par/views.py
@@ -865,10 +865,17 @@ def tools():
     headers = _parse_filter_headers(request)
     tools_filter = headers.get(TOOL_HEADER, None)
 
+    # Only include enabled tools.
+    tools = fpr_tools.query.filter_by(enabled=True)
+    id_tools = fpr_id_tools.query.filter_by(enabled=True)
 
-    # only include enabled tools.
-    tools = fpr_tools.query.filter_by(enabled=True).all()
-    id_tools = fpr_id_tools.query.filter_by(enabled=True).all()
+    # If we have a filter, only include tools that we've requested.
+    if tools_filter != []:
+        tools = tools.filter(fpr_tools.uuid.in_(tools_filter)).all()
+        id_tools = id_tools.filter(fpr_id_tools.uuid.in_(tools_filter)).all()
+    else:
+        tools = tools.all()
+        id_tools = id_tools.all()
 
     # concatenate our two lists.
     new_tools = (tools + id_tools)[offset:limit]

--- a/fpr2par/views.py
+++ b/fpr2par/views.py
@@ -1014,6 +1014,7 @@ def businessRules():
     headers = _parse_filter_headers(request)
     guid_filter = headers.get(GUID_HEADER, None)
     format_filter = headers.get(FILE_FORMAT_HEADER, None)
+    pres_act_filter = headers.get(PRESERVATION_ACT_HEADER, None)
 
     rules = (
         fpr_rules.query.filter_by(enabled=True)
@@ -1092,6 +1093,9 @@ def businessRules():
         actionType = par_preservation_action_types.query.filter_by(
             label=command.command_usage.lower()
         ).first()
+
+        if pres_act_filter != [] and actionType.uuid not in pres_act_filter:
+            continue
 
         newRule = {
             "id": {

--- a/fpr2par/views.py
+++ b/fpr2par/views.py
@@ -1022,6 +1022,8 @@ def businessRules():
         file_format = fpr_format_versions.query.get(rule.format)
         if format_filter != [] and file_format.pronom_id not in format_filter:
             continue
+        if guid_filter != [] and rule.uuid not in guid_filter:
+            continue
         if file_format.pronom_id:
             formatName = file_format.pronom_id
             if file_format.pronom_id[:3] == "arc":

--- a/fpr2par/views.py
+++ b/fpr2par/views.py
@@ -669,8 +669,10 @@ def preservationActions():
 
     offset, limit = _parse_offset_limit(request)
     before_date, after_date = _parse_filter_dates(request)
+
+    # Filter parsing using request headers.
     headers = _parse_filter_headers(request)
-    preservation_act_filter = headers.get(PRESERVATION_ACT_HEADER, None)
+    pres_act_filter = headers.get(PRESERVATION_ACT_HEADER, None)
     tool_filter = headers.get(TOOL_HEADER, None)
 
     dpActions = (
@@ -709,6 +711,12 @@ def preservationActions():
             tool = fpr_tools.query.get(action.tool)
             action_label = action.command_usage.lower()
             action_command = action.command
+
+        # Apply header-based filtering.
+        if tool_filter != [] and tool.uuid not in tool_filter:
+            continue
+        if pres_act_filter != [] and action_type.uuid not in pres_act_filter:
+            continue
 
         rules = fpr_rules.query.filter_by(command=action.uuid).all()
         if rules:
@@ -852,6 +860,8 @@ def tools():
     response["tools"] = []
 
     offset, limit = _parse_offset_limit(request)
+
+    # Filter parsing using request headers.
     headers = _parse_filter_headers(request)
     tools_filter = headers.get(TOOL_HEADER, None)
 
@@ -1011,6 +1021,7 @@ def businessRules():
     offset, limit = _parse_offset_limit(request)
     before_date, after_date = _parse_filter_dates(request)
 
+    # Filter parsing using request headers.
     headers = _parse_filter_headers(request)
     guid_filter = headers.get(GUID_HEADER, None)
     format_filter = headers.get(FILE_FORMAT_HEADER, None)

--- a/fpr2par/views.py
+++ b/fpr2par/views.py
@@ -669,6 +669,9 @@ def preservationActions():
 
     offset, limit = _parse_offset_limit(request)
     before_date, after_date = _parse_filter_dates(request)
+    headers = _parse_filter_headers(request)
+    preservation_act_filter = headers.get(PRESERVATION_ACT_HEADER, None)
+    tool_filter = headers.get(TOOL_HEADER, None)
 
     dpActions = (
         fpr_commands.query.filter_by(enabled=True)
@@ -849,6 +852,9 @@ def tools():
     response["tools"] = []
 
     offset, limit = _parse_offset_limit(request)
+    headers = _parse_filter_headers(request)
+    tools_filter = headers.get(TOOL_HEADER, None)
+
 
     # only include enabled tools.
     tools = fpr_tools.query.filter_by(enabled=True).all()

--- a/fpr2par/views.py
+++ b/fpr2par/views.py
@@ -1025,27 +1025,17 @@ def businessRules():
         else:
             formatName = slugify(file_format.description)
             formatNamespace = "https://archivematica.org"
-        name = (
-            str(command.fprTool)
-            + "-"
-            + rule.purpose
-            + "-"
-            + file_format.description
-            + "("
-            + file_format.pronom_id
-            + ")"
+        name = "{}-{}-{}({})".format(
+            command.fprTool,
+            rule.purpose,
+            file_format.description.strip(),
+            file_format.pronom_id)
+        description = "For {} of {} ({}), use {}".format(
+            rule.purpose,
+            file_format.description.strip(),
+            file_format.pronom_id,
+            command.fprTool,
         )
-        description = (
-            "For "
-            + rule.purpose
-            + " of "
-            + file_format.description
-            + "("
-            + file_format.pronom_id
-            + "), use "
-            + str(command.fprTool)
-        )
-
         priority = 1
         preservationActions = []
         preservationActions.append(

--- a/fpr2par/views.py
+++ b/fpr2par/views.py
@@ -19,7 +19,18 @@ from .models import (
     fpr_rules,
     par_preservation_action_types,
 )
-from .helpers import _parse_filter_dates, _parse_offset_limit
+
+from .helpers import (
+    # Parse functions associated with various API filter options.
+    _parse_filter_dates,
+    _parse_filter_headers,
+    _parse_offset_limit,
+    # Filter values associated with various API filter options.
+    GUID_HEADER,
+    FILE_FORMAT_HEADER,
+    PRESERVATION_ACT_HEADER,
+    TOOL_HEADER,
+)
 
 basic_auth = BasicAuth(app)
 
@@ -1004,33 +1015,33 @@ def businessRules():
     response["businessRules"] = []
     for rule in rules:
         command = fpr_commands.query.get(rule.command)
-        format = fpr_format_versions.query.get(rule.format)
-        if format.pronom_id:
-            formatName = format.pronom_id
-            if format.pronom_id[:3] == "arc":
+        file_format = fpr_format_versions.query.get(rule.format)
+        if file_format.pronom_id:
+            formatName = file_format.pronom_id
+            if file_format.pronom_id[:3] == "arc":
                 formatNamespace = "https://archivematica.org"
             else:
                 formatNamespace = "http://www.nationalarchives.uk.gov"
         else:
-            formatName = slugify(format.description)
+            formatName = slugify(file_format.description)
             formatNamespace = "https://archivematica.org"
         name = (
             str(command.fprTool)
             + "-"
             + rule.purpose
             + "-"
-            + format.description
+            + file_format.description
             + "("
-            + format.pronom_id
+            + file_format.pronom_id
             + ")"
         )
         description = (
             "For "
             + rule.purpose
             + " of "
-            + format.description
+            + file_format.description
             + "("
-            + format.pronom_id
+            + file_format.pronom_id
             + "), use "
             + str(command.fprTool)
         )
@@ -1085,7 +1096,7 @@ def businessRules():
                 "namespace": "https://archivematica.org",
             },
             "formats": [
-                {"guid": format.uuid, "name": formatName, "namespace": formatNamespace}
+                {"guid": file_format.uuid, "name": formatName, "namespace": formatNamespace}
             ],
             "preservationActions": preservationActions,
             "preservationActiontypes": [

--- a/fpr2par/views.py
+++ b/fpr2par/views.py
@@ -1005,6 +1005,10 @@ def businessRules():
     offset, limit = _parse_offset_limit(request)
     before_date, after_date = _parse_filter_dates(request)
 
+    headers = _parse_filter_headers(request)
+    guid_filter = headers.get(GUID_HEADER, None)
+    format_filter = headers.get(FILE_FORMAT_HEADER, None)
+
     rules = (
         fpr_rules.query.filter_by(enabled=True)
         .filter(fpr_rules.last_modified.between(after_date, before_date))
@@ -1016,6 +1020,8 @@ def businessRules():
     for rule in rules:
         command = fpr_commands.query.get(rule.command)
         file_format = fpr_format_versions.query.get(rule.format)
+        if format_filter != [] and file_format.pronom_id not in format_filter:
+            continue
         if file_format.pronom_id:
             formatName = file_format.pronom_id
             if file_format.pronom_id[:3] == "arc":


### PR DESCRIPTION
Just for business actions to begin with prep work done  for pres actions and tools. 

Example commands:

_Business rules_
```
curl -v \
    -H "Accept: application/json" \
    -H "file-format: fmt/437, fmt/367," \
    "http://127.0.0.1:5000/api/par/business-rules" 
```

```
curl -v \
    -H "Accept: application/json" \
    -H "file-format: fmt/101" \
    "http://127.0.0.1:5000/api/par/business-rules" 
```

```
curl -v \
    -H "Accept: application/json" \
    -H "guid: 5c9685e7-5694-4275-a4a7-c3ebdb6aa88a" \
    "http://127.0.0.1:5000/api/par/business-rules" 
```

```
curl -v \
    -H "Accept: application/json" \
    -H "preservation-action-type: 86bc1d5b-496d-4c8e-9e60-f54fecbb782d" \
    "http://127.0.0.1:5000/api/par/business-rules" 
```

_Preservation actions_
```
curl -v \
    -H "Accept: application/json" \
    -H "tool: 085d8690-93b7-4d31-84f7-2c5f4cbf6735" \
    "http://127.0.0.1:5000/api/par/preservation-actions" 
```

```
curl -v \
    -H "Accept: application/json" \
    -H "preservation-action-type: 86bc1d5b-496d-4c8e-9e60-f54fecbb782d" \
    "http://127.0.0.1:5000/api/par/preservation-actions" 
```

_Tools_
```bash
curl -v \
    -H "Accept: application/json" \
    -H "tool: 52621750-1f8f-410d-aa1b-eb0a34103d51" \
    "http://127.0.0.1:5000/api/par/tools" 
```

Connected to https://github.com/artefactual-labs/fpr2par/issues/63
Connected to https://github.com/artefactual-labs/fpr2par/issues/64
Connected to https://github.com/artefactual-labs/fpr2par/issues/65
Connected to https://github.com/artefactual-labs/fpr2par/issues/66
Connected to https://github.com/artefactual-labs/fpr2par/issues/67
Connected to https://github.com/artefactual-labs/fpr2par/issues/69