### PR TITLE
Convert tool filter to a guid filter per the specification

### DIFF
--- a/fpr2par/helpers.py
+++ b/fpr2par/helpers.py
@@ -38,6 +38,7 @@ DATE_FORMAT_PARTIAL = "%Y-%m-%d"
 GUID_HEADER = "guid"
 FILE_FORMAT_HEADER = "file-format"
 PRESERVATION_ACT_HEADER = "preservation-action-type"
+TOOL_HEADER = "tool"
 
 
 def _parse_filter_dates(request):
@@ -78,8 +79,10 @@ def _parse_filter_headers(request):
     preservation_act_header = _get_filter_list(
         request.headers.get(PRESERVATION_ACT_HEADER)
     )
+    tool_header = _get_filter_list(request.headers.get(TOOL_HEADER))
     return {
         GUID_HEADER: guid_header,
         FILE_FORMAT_HEADER: file_format_header,
         PRESERVATION_ACT_HEADER: preservation_act_header,
+        TOOL_HEADER: tool_header,
     }

--- a/fpr2par/views.py
+++ b/fpr2par/views.py
@@ -1008,7 +1008,7 @@ def tools():
 
     # Filter parsing using request headers.
     headers = _parse_filter_headers(request)
-    tools_filter = headers.get(TOOL_HEADER, None)
+    tools_filter = headers.get(GUID_HEADER, None)
 
     # Only include enabled tools.
     tools = fpr_tools.query.filter_by(enabled=True)

--- a/fpr2par/views.py
+++ b/fpr2par/views.py
@@ -29,6 +29,7 @@ from .helpers import (
     GUID_HEADER,
     FILE_FORMAT_HEADER,
     PRESERVATION_ACT_HEADER,
+    TOOL_HEADER,
 )
 
 basic_auth = BasicAuth(app)
@@ -1007,7 +1008,7 @@ def tools():
 
     # Filter parsing using request headers.
     headers = _parse_filter_headers(request)
-    tools_filter = headers.get(GUID_HEADER, None)
+    tools_filter = headers.get(TOOL_HEADER, None)
 
     # Only include enabled tools.
     tools = fpr_tools.query.filter_by(enabled=True)


### PR DESCRIPTION
This should work with a GUID header field now, using the following as my test (`FIDO` and `unrar`):
```
curl -v \
    -H "Accept: application/json" \
    -H "guid: 52621750-1f8f-410d-aa1b-eb0a34103d51, c33c9d4d-121f-4db1-aa31-3d248c705e44" \
    "http://127.0.0.1:5000/api/par/tools" 
```